### PR TITLE
Update wiresharkRemote Function

### DIFF
--- a/zsh/include/functions.zsh
+++ b/zsh/include/functions.zsh
@@ -97,7 +97,7 @@ wiresharkRemote() {
 	host="${1}"
 	shift
 
-	ssh "${host}" nix run nixpkgs.tcpdump -c tcpdump -U -s0 -w - ${*} | wireshark -k -i -
+	ssh "${host}" nix run nixpkgs.tcpdump -c sudo tcpdump -U -s0 -w - ${*} | nix run nixpkgs.wireshark -c wireshark -k -i -
 }
 
 source "$zshincl/extract.zsh"


### PR DESCRIPTION
make wiresharkRemote function to work with systems where root is required and/or where wireshark is not installed